### PR TITLE
[other] NO-TICKET: Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @BranchMetrics/disco-sdk
+* @BranchMetrics/sdk-maintainers 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @BranchMetrics/disco-sdk


### PR DESCRIPTION
Assigns ownership via CODEOWNERS (* @BranchMetrics/disco-sdk) as part of the service-catalogue rollout.